### PR TITLE
ENH: added instruments

### DIFF
--- a/src/GMM.jl
+++ b/src/GMM.jl
@@ -156,7 +156,7 @@ function row_kron{S,T}(A::Matrix{S}, B::Matrix{T})
     for ia=1:na
         for ib=1:nb
             for t=1:nobsa
-                out[t, nb*(ia-1) + ib] = A[t, ia] * B[t, ib]
+                @inbounds out[t, nb*(ia-1) + ib] = A[t, ia] * B[t, ib]
             end
         end
     end

--- a/src/GMM.jl
+++ b/src/GMM.jl
@@ -213,8 +213,6 @@ function gmm(mf::Function, theta::Vector, theta_l::Vector, theta_u::Vector,
     nobs, nmom = size(mf0)
     npar       = length(theta)
 
-    @show nmom
-
     nl         = length(theta_l)
     nu         = length(theta_u)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+module GMMtests
+
 using GMM
 using FactCheck
 
@@ -31,3 +33,27 @@ facts("Testing basic interface") do
         @fact pe => roughly(pt, atol=1e-3)
     end
 end
+
+facts("Test utilities") do
+    context("test row_kron") do
+        h = ["a" "b"; "c" "d"]
+        z = ["1" "2" "3"; "4" "5" "6"]
+        want = ["a1" "a2" "a3" "b1" "b2" "b3"; "c4" "c5" "c6" "d4" "d5" "d6"]
+        @fact GMM.row_kron(h, z) => want
+
+        # now test on some bigger matrices
+        a = randn(400, 3)
+        b = randn(400, 5)
+        out = GMM.row_kron(a, b)
+        @fact size(out) => (400, 15)
+
+        rows_good = true
+        for row=1:400
+            rows_good = out[row, :] == kron(a[row, :], b[row, :])
+        end
+        @fact rows_good => true
+    end
+end
+
+
+end  # module


### PR DESCRIPTION
First pass at implementing automatic instrumental variable support. The `row_kron` method has a few tests and is as efficient as I could make it. I tried three other implementations and this one was by far the fastest (about 50x faster than next closest).

Comments welcome about use of `Union(Nothing, Matrix{Float64})`. I have mixed feelings about it. It isn't necessarily clean, but it lets us not do the extra work of `row_kron` when we don't have any additional instruments. 
